### PR TITLE
Add program argument in vscode configuration

### DIFF
--- a/lib/processors/ide/vscode/models/configuration.dart
+++ b/lib/processors/ide/vscode/models/configuration.dart
@@ -39,12 +39,15 @@ class Configuration {
 
   final List<String> args;
 
+  final String program;
+
   Configuration({
     this.name,
     this.request,
     this.type,
     this.flutterMode,
     this.args,
+    this.program,
   });
 
   Map<String, dynamic> toJson() => _$ConfigurationToJson(this);

--- a/lib/processors/ide/vscode/models/configuration.g.dart
+++ b/lib/processors/ide/vscode/models/configuration.g.dart
@@ -13,4 +13,5 @@ Map<String, dynamic> _$ConfigurationToJson(Configuration instance) =>
       'type': instance.type,
       'flutterMode': instance.flutterMode,
       'args': instance.args,
+      'program': instance.program,
     };

--- a/lib/processors/ide/vscode/vscode_launch_processor.dart
+++ b/lib/processors/ide/vscode/vscode_launch_processor.dart
@@ -48,6 +48,7 @@ class VSCodeLaunchProcessor extends StringProcessor {
                     '--flavor',
                     flavorName,
                   ],
+                  program: 'lib/main-$flavorName.dart',
                 ),
               ),
             )


### PR DESCRIPTION
Hello,

It seems that the _program_ argument was missing from the launch.json file. 
This PR simply adds it to the configuration file, and link it to main-_flavor_.dart. 