### PR TITLE
Fix: Flutter expects a build configuration named Debug- or similar.

### DIFF
--- a/assets/scripts/ios/create_scheme.rb
+++ b/assets/scripts/ios/create_scheme.rb
@@ -12,10 +12,10 @@ project = Xcodeproj::Project.open(project_path)
 target = project.targets.first
 
 scheme = Xcodeproj::XCScheme.new
-scheme.launch_action.build_configuration = "Debug #{scheme_name}"
+scheme.launch_action.build_configuration = "Debug-#{scheme_name}"
 scheme.set_launch_target(target)
-scheme.test_action.build_configuration = "Debug #{scheme_name}"
-scheme.profile_action.build_configuration = "Release #{scheme_name}"
-scheme.analyze_action.build_configuration = "Debug #{scheme_name}"
-scheme.archive_action.build_configuration = "Release #{scheme_name}"
+scheme.test_action.build_configuration = "Debug-#{scheme_name}"
+scheme.profile_action.build_configuration = "Release-#{scheme_name}"
+scheme.analyze_action.build_configuration = "Debug-#{scheme_name}"
+scheme.archive_action.build_configuration = "Release-#{scheme_name}"
 scheme.save_as(project_path, scheme_name)


### PR DESCRIPTION
The script adds a space instead of - to the build configuration, this results in an error when building the app:

`Flutter expects a build configuration named Debug-#SCHEME_NAME`

Fixes issue https://github.com/AngeloAvv/flutter_flavorizr/issues/22