### PR TITLE
fix(android_firebase_processor): name json file in kebab-case instead of snake_case

### DIFF
--- a/lib/processors/android/google/firebase/android_firebase_processor.dart
+++ b/lib/processors/android/google/firebase/android_firebase_processor.dart
@@ -34,7 +34,7 @@ class AndroidFirebaseProcessor extends QueueProcessor {
     String flavorName,
   ) : super([
           NewFolderProcessor('$destination/$flavorName'),
-          CopyFileProcessor(source, '$destination/$flavorName/google_services.json'),
+          CopyFileProcessor(source, '$destination/$flavorName/google-services.json'),
         ]);
 
   @override


### PR DESCRIPTION
A small problem I encountered in where the Gradle is expecting to find a `google-services.json` file, but we are generating a `google_services.json` file.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:processDevDebugGoogleServices'.
> File google-services.json is missing. The Google Services Plugin cannot function without it.
   Searched Location:
  /Users/jrc/newalphadev/new/android/app/src/dev/debug/google-services.json
  /Users/jrc/newalphadev/new/android/app/src/debug/dev/google-services.json
  /Users/jrc/newalphadev/new/android/app/src/dev/google-services.json
  /Users/jrc/newalphadev/new/android/app/src/debug/google-services.json
  /Users/jrc/newalphadev/new/android/app/src/devDebug/google-services.json
  /Users/jrc/newalphadev/new/android/app/google-services.json


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```

```
$ ls android/app/src/dev
res/  google_services.json  # << should be google-services.json
```