### PR TITLE
add return type for method _initAvailableProcessors and fix google-service.json name

### DIFF
--- a/lib/processors/android/google/firebase/android_target_firebase_processor.dart
+++ b/lib/processors/android/google/firebase/android_target_firebase_processor.dart
@@ -34,7 +34,7 @@ class AndroidTargetFirebaseProcessor extends QueueProcessor {
     String flavorName,
   ) : super([
           NewFolderProcessor('$destination/$flavorName'),
-          CopyFileProcessor(source, '$destination/$flavorName/google_services.json'),
+          CopyFileProcessor(source, '$destination/$flavorName/google-services.json'),
         ]);
 
   @override

--- a/lib/processors/processor.dart
+++ b/lib/processors/processor.dart
@@ -109,7 +109,7 @@ class Processor extends AbstractProcessor<void> {
     }
   }
 
-  static _initAvailableProcessors(Pubspec pubspec) {
+  static Map<String, AbstractProcessor<void>> _initAvailableProcessors(Pubspec pubspec) {
     return {
       // Commons
       'assets:download': DownloadFileProcessor(


### PR DESCRIPTION
missing return type generate type error:

```
Unhandled exception:
type '_InternalLinkedHashMap<String, Object>' is not a subtype of type 'Map<String, AbstractProcessor<void>>'
#0      new Processor (package:flutter_flavorizr/processors/processor.dart:91:51)
...
```
