### PR TITLE
🎨 Add profile to config processor

### DIFF
--- a/lib/processors/ios/xcconfig/ios_xcconfig_file_processor.dart
+++ b/lib/processors/ios/xcconfig/ios_xcconfig_file_processor.dart
@@ -27,7 +27,7 @@ import 'package:flutter_flavorizr/processors/commons/queue_processor.dart';
 import 'package:flutter_flavorizr/processors/ios/xcconfig/ios_xcconfig_mode_file_processor.dart';
 
 class IOSXCConfigFileProcessor extends QueueProcessor {
-  static const List<String> _modes = ['Debug', 'Release'];
+  static const List<String> _modes = ['Debug', 'Profile', 'Release'];
 
   IOSXCConfigFileProcessor(
     String process,


### PR DESCRIPTION
Add Profile to config processor mode array to generate app name for Profile mode (on the picture below, the name was missing before this PR).

<img width="457" alt="Capture d’écran 2021-06-10 à 09 56 18" src="https://user-images.githubusercontent.com/65351784/121487379-51587980-c9d2-11eb-987c-75c19394b9cd.png">
