### PR TITLE
✨ Add custom runner path

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ flavorizr:
 | key  | type   | default | required | description         |
 |:-----|:-------|:--------|:---------|:--------------------|
 | name | String |         | true     | The name of the App |
+| runner_path | String | lib/main-<FLAVOR_NAME>.dart | false     | The custom path of the runner dart file |
 
 #### android (under *flavorname*)
 

--- a/lib/parser/models/flavors/app.dart
+++ b/lib/parser/models/flavors/app.dart
@@ -30,8 +30,10 @@ part 'app.g.dart';
 class App {
   @JsonKey(required: true, disallowNullValue: true)
   final String name;
+  @JsonKey()
+  final String? runner_path;
 
-  App({required this.name});
+  App({required this.name, this.runner_path});
 
   factory App.fromJson(Map<String, dynamic> json) => _$AppFromJson(json);
 }

--- a/lib/parser/models/flavors/app.g.dart
+++ b/lib/parser/models/flavors/app.g.dart
@@ -11,5 +11,6 @@ App _$AppFromJson(Map json) {
       requiredKeys: const ['name'], disallowNullValues: const ['name']);
   return App(
     name: json['name'] as String,
+    runner_path: json['runner_path'] as String?,
   );
 }

--- a/lib/processors/ios/xcconfig/ios_xcconfig_file_processor.dart
+++ b/lib/processors/ios/xcconfig/ios_xcconfig_file_processor.dart
@@ -36,6 +36,7 @@ class IOSXCConfigFileProcessor extends QueueProcessor {
     String path,
     String appName,
     String flavorName,
+    String? runnerPath,
   ) : super(
           _modes.map(
             (String mode) => IOSXCConfigModeFileProcessor(
@@ -45,6 +46,7 @@ class IOSXCConfigFileProcessor extends QueueProcessor {
               '$path/$flavorName$mode.xcconfig',
               appName,
               flavorName,
+              runnerPath,
             ),
           ),
         );

--- a/lib/processors/ios/xcconfig/ios_xcconfig_mode_file_processor.dart
+++ b/lib/processors/ios/xcconfig/ios_xcconfig_mode_file_processor.dart
@@ -37,12 +37,14 @@ class IOSXCConfigModeFileProcessor extends QueueProcessor {
     String file,
     String appName,
     String flavorName,
+    String? runnerPath,
   ) : super([
           NewFileStringProcessor(
             file,
             IOSXCConfigProcessor(
               appName,
               flavorName,
+              runnerPath: runnerPath,
             ),
           ),
           ShellProcessor(

--- a/lib/processors/ios/xcconfig/ios_xcconfig_processor.dart
+++ b/lib/processors/ios/xcconfig/ios_xcconfig_processor.dart
@@ -28,12 +28,16 @@ import 'package:flutter_flavorizr/processors/commons/string_processor.dart';
 class IOSXCConfigProcessor extends StringProcessor {
   final String _appName;
   final String _flavorName;
+  late final String? _runnerPath;
 
   IOSXCConfigProcessor(
     this._appName,
     this._flavorName, {
     String? input,
-  }) : super(input: input);
+    String? runnerPath,
+  }) : super(input: input) {
+    this._runnerPath = runnerPath;
+  }
 
   @override
   String execute() {
@@ -51,7 +55,8 @@ class IOSXCConfigProcessor extends StringProcessor {
 
   void _appendBody(StringBuffer buffer) {
     buffer.writeln();
-    buffer.writeln('FLUTTER_TARGET=lib/main-$_flavorName.dart');
+    var flutterTarget = this._runnerPath != null && this._runnerPath!.length > 0 ? _runnerPath : 'lib/main-$_flavorName.dart';
+    buffer.writeln('FLUTTER_TARGET=$flutterTarget');
     buffer.writeln();
     buffer.writeln('ASSET_PREFIX=$_flavorName');
     buffer.writeln('BUNDLE_NAME=$_appName');

--- a/lib/processors/ios/xcconfig/ios_xcconfig_targets_file_processor.dart
+++ b/lib/processors/ios/xcconfig/ios_xcconfig_targets_file_processor.dart
@@ -44,6 +44,7 @@ class IOSXCConfigTargetsFileProcessor extends QueueProcessor {
                   path,
                   flavor.app.name,
                   flavorName,
+                  flavor.app.runner_path,
                 )))
             .values);
 


### PR DESCRIPTION
Add a way to customize the path of the dart file runner.

**How ?**

Add in the pubspec.yaml the following key:

```yaml
flavorizr:
  app:
  flavors:
    customFlavor:
      app:
        name: "My Flavor"
        runner_path: "./lib/runner/your_custom_runner.dart"
```

**Why ?**

When we use the custom ```-p``` command to bypass generating flavors dart file from the library, we want to use our custom runners files. 