### PR TITLE
print error information

### DIFF
--- a/lib/processors/commons/shell_processor.dart
+++ b/lib/processors/commons/shell_processor.dart
@@ -39,11 +39,16 @@ class ShellProcessor extends AbstractProcessor<void> {
   });
 
   @override
-  void execute() => Process.runSync(
-        _path,
-        _args,
-        workingDirectory: workingDirectory,
-      );
+  void execute() {
+    ProcessResult result = Process.runSync(
+      _path,
+      _args,
+      workingDirectory: workingDirectory,
+    );
+    if (result.exitCode != 0) {
+      print(result.stderr);
+    }
+  }
 
   @override
   String toString() =>


### PR DESCRIPTION
This happened to me when the execution of commands was not always successful. But since no information is being output, it's hard to figure out what went wrong.