### PR TITLE
Rename icon prefix under the ios group

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ By default, when you do not specify a custom set of processors by appending the 
 * ios:buildTargets
 * ios:schema
 * ios:dummyAssets
-* android:icons
+* ios:icons
 * ios:plist
 * ios:launchScreen
 * google:firebase


### PR DESCRIPTION
The icon prefix under the Default processors set -> ios sections had `android` as prefix, which should have been `ios`.