### PR TITLE
ImageProcessor: Create file path if not existing when copying icon sets

### DIFF
--- a/lib/processors/commons/image_resizer_processor.dart
+++ b/lib/processors/commons/image_resizer_processor.dart
@@ -64,7 +64,9 @@ class ImageResizerProcessor extends CopyFileProcessor {
       throw MalformedResourceException(source);
     }
 
-    return File(destination)..writeAsBytesSync(encodedImage);
+    return File(destination)
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(encodedImage);
   }
 
   @override


### PR DESCRIPTION
`android:icons` and `ios:icons` processor fails to complete if asset folders weren't created before or were deleted for some reason after the first `flavorizr` execution. 

Adding `creatSync(recursive: true)` to the file write chain makes sure to create the missing directory path if it's missing.