### PR TITLE
Set letters lowercase when created flavors

### DIFF
--- a/lib/processors/flutter/flutter_flavors_processor.dart
+++ b/lib/processors/flutter/flutter_flavors_processor.dart
@@ -50,7 +50,7 @@ class FlutterFlavorsProcessor extends StringProcessor {
     buffer.writeln('enum Flavor {');
 
     for (var flavorName in config.flavors.keys) {
-      buffer.writeln('  ${flavorName.toUpperCase()},');
+      buffer.writeln('  ${flavorName.toLowerCase()},');
     }
 
     buffer.writeln('}');
@@ -69,7 +69,7 @@ class FlutterFlavorsProcessor extends StringProcessor {
     buffer.writeln('    switch (appFlavor) {');
 
     config.flavors.forEach((String name, Flavor flavor) {
-      buffer.writeln('      case Flavor.${name.toUpperCase()}:');
+      buffer.writeln('      case Flavor.${name.toLowerCase()}:');
       buffer.writeln('        return \'${flavor.app.name}\';');
     });
 

--- a/lib/processors/flutter/target/flutter_target_file_processor.dart
+++ b/lib/processors/flutter/target/flutter_target_file_processor.dart
@@ -46,7 +46,7 @@ class FlutterTargetFileProcessor extends QueueProcessor {
               '$destination/main_$flavorName.dart',
               ReplaceStringProcessor(
                 '[[FLAVOR_NAME]]',
-                flavorName.toUpperCase(),
+                flavorName.toLowerCase(),
                 config: config,
               ),
               config: config,


### PR DESCRIPTION
when generated flavors.dart file show this warning from dart:

```
The constant name 'MYFLAVOR' isn't a lowerCamelCase identifier.
Try changing the name to follow the lowerCamelCase style.dartconstant_identifier_names

dart(constant_identifier_names)
```