### PR TITLE
#209 Fixes PathNotFoundException: Cannot open file (OS Error: No such file or directory, errno = 2)

### DIFF
--- a/lib/src/processors/commons/new_file_string_processor.dart
+++ b/lib/src/processors/commons/new_file_string_processor.dart
@@ -37,4 +37,10 @@ class NewFileStringProcessor extends AbstractFileStringProcessor {
           processor,
           config: config,
         );
+
+  @override
+  void execute() {
+    file.createSync(recursive: true);
+    super.execute();
+  }
 }


### PR DESCRIPTION
FIxes  #209 

PathNotFoundException: Cannot open file, path = '.idea/runConfigurations/main_dev_dart.xml' (OS Error: No such file or directory, errno = 2)