### PR TITLE
Fixes add_firebase_build_phase script output paths

### DIFF
--- a/assets/scripts/darwin/add_firebase_build_phase.rb
+++ b/assets/scripts/darwin/add_firebase_build_phase.rb
@@ -21,8 +21,7 @@ phase = target.new_shell_script_build_phase('Firebase Setup')
 phase.shell_path = '/bin/sh'
 phase.shell_script = content
 phase.run_only_for_deployment_postprocessing = '0'
-phase.simple_attributes.find { |attribute| attribute.plist_name == 'outputPaths' }
-     .default_value << '$(SRCROOT)/Runner/GoogleService-Info.plist'
+phase.output_paths.append('$(SRCROOT)/Runner/GoogleService-Info.plist')
 
 target.build_phases.rotate!(-1)
 


### PR DESCRIPTION
We decided to add Runner/GoogleService-Info.plist file to gitignore so we could avoid conflicts due to a auto-generated file

because of this some errors started to be shown on our CI, and it's because the assets/scripts/darwin/add_firebase_build_phase.rb wasnt defining 'Runner/GoogleService-Info.plist' as an output declaration to the build_phase.

While debugging i found the solution: 
https://www.rubydoc.info/github/CocoaPods/Xcodeproj/Xcodeproj/Project/Object/PBXShellScriptBuildPhase

Previous output:

```
name = "Firebase Setup";
outputFileListPaths = (
);
outputPaths = (
);
```

Fixed output:
```
name = "Firebase Setup";
outputFileListPaths = (
);
outputPaths = (
"$(SRCROOT)/Runner/GoogleService-Info.plist",
);
```