### PR TITLE
✨Fix: Support dot-notation in customConfig when generating Kotlin DSL

### DIFF
--- a/lib/src/processors/android/build_gradle/android_flavorizr_kotlin_processor.dart
+++ b/lib/src/processors/android/build_gradle/android_flavorizr_kotlin_processor.dart
@@ -64,34 +64,35 @@ class AndroidFlavorizrKotlinProcessor extends StringProcessor {
   void _appendStartContent(StringBuffer buffer) {
     buffer.writeln('import com.android.build.gradle.AppExtension');
     buffer.writeln('');
-    buffer.writeln(
-        'val android = project.extensions.getByType(AppExtension::class.java)');
+    buffer.writeln('val android = project.extensions.getByType(AppExtension::class.java)');
     buffer.writeln('');
     buffer.writeln('android.apply {');
   }
 
   void _appendFlavorsDimension(StringBuffer buffer) {
-    final flavorDimension =
-        config.app?.android?.flavorDimensions ?? Android.kFlavorDimensionValue;
+    final flavorDimension = config.app?.android?.flavorDimensions ?? Android.kFlavorDimensionValue;
 
     buffer.writeln('    flavorDimensions("$flavorDimension")');
     buffer.writeln();
   }
 
   void _appendFlavors(StringBuffer buffer) {
-    final flavorDimension =
-        config.app?.android?.flavorDimensions ?? Android.kFlavorDimensionValue;
+    final flavorDimension = config.app?.android?.flavorDimensions ?? Android.kFlavorDimensionValue;
 
     buffer.writeln('    productFlavors {');
 
     config.androidFlavors.forEach((name, flavor) {
       buffer.writeln('        create("$name") {');
       buffer.writeln('            dimension = "$flavorDimension"');
-      buffer.writeln(
-          '            applicationId = "${flavor.android?.applicationId}"');
+      buffer.writeln('            applicationId = "${flavor.android?.applicationId}"');
 
       flavor.android?.customConfig.forEach((key, value) {
-        buffer.writeln('            $key = $value');
+        if (key.startsWith('manifestPlaceholders.')) {
+          final placeholderKey = key.split('.').last;
+          buffer.writeln('            manifestPlaceholders["$placeholderKey"] = "$value"');
+        } else {
+          buffer.writeln('            $key = $value');
+        }
       });
 
       final Map<String, ResValue> resValues = LinkedHashMap.from({
@@ -108,8 +109,7 @@ class AndroidFlavorizrKotlinProcessor extends StringProcessor {
         );
       });
 
-      final Map<String, BuildConfigField> buildConfigFields =
-          LinkedHashMap.fromEntries([
+      final Map<String, BuildConfigField> buildConfigFields = LinkedHashMap.fromEntries([
         ...config.app?.android?.buildConfigFields.entries ?? [],
         ...flavor.android?.buildConfigFields.entries ?? []
       ]);

--- a/test/processors/android/build_flavorizr_processor_test/build_flavorizr_kotlin_processor_test.dart
+++ b/test/processors/android/build_flavorizr_processor_test/build_flavorizr_kotlin_processor_test.dart
@@ -64,7 +64,6 @@ void main() {
       logger: logger,
     );
     String actual = processor.execute();
-    print(actual);
     actual = TestUtils.stripEndOfLines(actual);
     matcher = TestUtils.stripEndOfLines(matcher);
 

--- a/test/processors/android/build_flavorizr_processor_test/build_flavorizr_kotlin_processor_test.dart
+++ b/test/processors/android/build_flavorizr_processor_test/build_flavorizr_kotlin_processor_test.dart
@@ -64,7 +64,7 @@ void main() {
       logger: logger,
     );
     String actual = processor.execute();
-
+    print(actual);
     actual = TestUtils.stripEndOfLines(actual);
     matcher = TestUtils.stripEndOfLines(matcher);
 

--- a/test/processors/android/build_flavorizr_processor_test/pubspec_with_custom_config.yaml
+++ b/test/processors/android/build_flavorizr_processor_test/pubspec_with_custom_config.yaml
@@ -49,7 +49,11 @@ flavorizr:
           signingConfig: flavorSigning.green
           versionCode: 1000
           minSdkVersion: 23
-          manifestPlaceholders.appScheme: "appleScheme"
+          manifestPlaceholders:
+            appScheme: "appleScheme"
+            deep:
+              level:
+                item: "x"
 
       ios:
         bundleId: "com.example.apple"
@@ -67,7 +71,11 @@ flavorizr:
       android:
         applicationId: "com.example.banana"
         customConfig:
-          manifestPlaceholders.appScheme: "bananaScheme"
+          manifestPlaceholders:
+            appScheme: "bananaScheme"
+            deep:
+              level:
+                item: "y"
         resValues:
           variable_one:
             type: "string"

--- a/test/processors/android/build_flavorizr_processor_test/pubspec_with_custom_config.yaml
+++ b/test/processors/android/build_flavorizr_processor_test/pubspec_with_custom_config.yaml
@@ -49,6 +49,7 @@ flavorizr:
           signingConfig: flavorSigning.green
           versionCode: 1000
           minSdkVersion: 23
+          manifestPlaceholders.appScheme: "appleScheme"
 
       ios:
         bundleId: "com.example.apple"
@@ -65,6 +66,8 @@ flavorizr:
 
       android:
         applicationId: "com.example.banana"
+        customConfig:
+          manifestPlaceholders.appScheme: "bananaScheme"
         resValues:
           variable_one:
             type: "string"

--- a/test_resources/android/build_flavorizr_processor_test/flavorizr_kotlin_expected.gradle.kts
+++ b/test_resources/android/build_flavorizr_processor_test/flavorizr_kotlin_expected.gradle.kts
@@ -13,6 +13,7 @@ android.apply {
             signingConfig = flavorSigning.green
             versionCode = 1000
             minSdkVersion = 23
+            manifestPlaceholders["appScheme"] = "appleScheme"
             resValue(type = "string", name = "app_name", value = "Apple App")
             resValue(type = "string", name = "variable_one", value = "previous variable one")
             resValue(type = "string", name = "common", value = "test common")
@@ -21,6 +22,7 @@ android.apply {
         create("banana") {
             dimension = "flavor-type"
             applicationId = "com.example.banana"
+            manifestPlaceholders["appScheme"] = "bananaScheme"
             resValue(type = "string", name = "app_name", value = "Banana\\' App")
             resValue(type = "string", name = "variable_one", value = "test variable\\' one")
             resValue(type = "string", name = "common", value = "test common")

--- a/test_resources/android/build_flavorizr_processor_test/flavorizr_kotlin_expected.gradle.kts
+++ b/test_resources/android/build_flavorizr_processor_test/flavorizr_kotlin_expected.gradle.kts
@@ -14,6 +14,7 @@ android.apply {
             versionCode = 1000
             minSdkVersion = 23
             manifestPlaceholders["appScheme"] = "appleScheme"
+            manifestPlaceholders["deep"]["level"]["item"] = "x"
             resValue(type = "string", name = "app_name", value = "Apple App")
             resValue(type = "string", name = "variable_one", value = "previous variable one")
             resValue(type = "string", name = "common", value = "test common")
@@ -23,6 +24,7 @@ android.apply {
             dimension = "flavor-type"
             applicationId = "com.example.banana"
             manifestPlaceholders["appScheme"] = "bananaScheme"
+            manifestPlaceholders["deep"]["level"]["item"] = "y"
             resValue(type = "string", name = "app_name", value = "Banana\\' App")
             resValue(type = "string", name = "variable_one", value = "test variable\\' one")
             resValue(type = "string", name = "common", value = "test common")

--- a/test_resources/android/build_flavorizr_processor_test/flavorizr_legacy_expected.gradle
+++ b/test_resources/android/build_flavorizr_processor_test/flavorizr_legacy_expected.gradle
@@ -9,6 +9,8 @@ android {
             signingConfig flavorSigning.green
             versionCode 1000
             minSdkVersion 23
+            manifestPlaceholders.appScheme "appleScheme"
+            manifestPlaceholders.deep.level.item "x"
             resValue "string", "app_name", "Apple App"
             resValue "string", "variable_one", "previous variable one"
             resValue "string", "common", "test common"
@@ -17,6 +19,8 @@ android {
         banana {
             dimension "flavor-type"
             applicationId "com.example.banana"
+            manifestPlaceholders.appScheme "bananaScheme"
+            manifestPlaceholders.deep.level.item "y"
             resValue "string", "app_name", "Banana\\' App"
             resValue "string", "variable_one", "test variable\\' one"
             resValue "string", "common", "test common"


### PR DESCRIPTION
When using keys like:
```
customConfig:
  manifestPlaceholders.appScheme: "value"
```
flutter_flavorizr generates invalid Kotlin:
`manifestPlaceholders.appScheme = "value"`

This PR transforms dot-notation into proper map syntax:
`manifestPlaceholders["appScheme"] = "value"`

### What This PR Fixes

This PR adds support for dot-notation in custom configuration keys by:
	•	Detecting keys that contain . (e.g., manifestPlaceholders.appScheme)
	•	Splitting the key into parent and child segments
	•	Generating valid Kotlin DSL map-style assignments
	
### Why This Matters

Without this fix, any flavor configuration using manifestPlaceholders.* or similar nested structures produces invalid Gradle Kotlin DSL syntax, causing build failures.
