### PR TITLE
fix: reuse existing build configuration to avoid duplicates on rerun

### DIFF
--- a/lib/src/processors/darwin/darwin_add_build_configuration_processor.dart
+++ b/lib/src/processors/darwin/darwin_add_build_configuration_processor.dart
@@ -55,12 +55,16 @@ class DarwinAddBuildConfigurationProcessor extends AbstractProcessor<void> {
     final fileRef = project.files.firstWhere((f) => f.path == xconfigPath);
     final nativeTarget = project.targets.first as PBXNativeTarget;
 
-    final targetConfig = project.newObject<XCBuildConfiguration>(
-        (g, u) => XCBuildConfiguration(g, u));
-    targetConfig.name = configName;
+    final targetConfigList = nativeTarget.buildConfigurationList!;
+    var targetConfig = targetConfigList[configName];
+    if (targetConfig == null) {
+      targetConfig = project
+          .newObject<XCBuildConfiguration>((g, u) => XCBuildConfiguration(g, u));
+      targetConfig.name = configName;
+      targetConfigList.buildConfigurations.add(targetConfig);
+    }
     targetConfig.buildSettings = {'PRODUCT_NAME': r'$(TARGET_NAME)'};
     targetConfig.baseConfigurationReference = fileRef;
-    nativeTarget.buildConfigurationList!.buildConfigurations.add(targetConfig);
 
     final baseConfig =
         project.buildConfigurations.firstWhere((c) => c.name == mode);

--- a/test/processors/darwin/darwin_add_build_configuration_processor_test.dart
+++ b/test/processors/darwin/darwin_add_build_configuration_processor_test.dart
@@ -78,6 +78,71 @@ void main() {
   });
 
   test(
+      'Test DarwinAddBuildConfigurationProcessor is idempotent and updates configurations in place on rerun',
+      () async {
+    await TestUtils.withTempDir((dir) async {
+      final projectPath = '${dir.path}/Runner.xcodeproj';
+      copyPathSync(exampleProjectPath, projectPath);
+
+      const modes = ['Debug', 'Profile', 'Release'];
+
+      Future<void> run(String mode, String xcconfig) =>
+          DarwinAddBuildConfigurationProcessor(
+            projectPath,
+            xcconfig,
+            'orange',
+            mode,
+            const {'PRODUCT_BUNDLE_IDENTIFIER': 'com.example.orange'},
+            config: flavorizr,
+            logger: logger,
+          ).execute();
+
+      for (final mode in modes) {
+        await run(mode, 'Flutter/apple$mode.xcconfig');
+      }
+
+      final afterFirst = await XcodeProject.open(projectPath);
+      final originalUuids = {
+        for (final mode in modes)
+          mode: afterFirst.targets.first.buildConfigurationList!
+              .buildConfigurations
+              .firstWhere((c) => c.name == '$mode-orange')
+              .uuid,
+      };
+
+      for (final mode in modes) {
+        await run(mode, 'Flutter/appleDebug.xcconfig');
+      }
+
+      final reopened = await XcodeProject.open(projectPath);
+      final target = reopened.targets.first;
+      final debugRef = reopened.files
+          .firstWhere((f) => f.path == 'Flutter/appleDebug.xcconfig');
+
+      for (final mode in modes) {
+        final targetMatches = target.buildConfigurationList!.buildConfigurations
+            .where((c) => c.name == '$mode-orange')
+            .toList();
+
+        expect(targetMatches.length, 1,
+            reason: '$mode-orange must not be duplicated on the target');
+        expect(
+          reopened.buildConfigurations
+              .where((c) => c.name == '$mode-orange')
+              .length,
+          1,
+          reason: '$mode-orange must not be duplicated on the project',
+        );
+
+        final config = targetMatches.single;
+        expect(config.uuid, originalUuids[mode]);
+        expect(config.buildSettings['PRODUCT_NAME'], r'$(TARGET_NAME)');
+        expect(config.baseConfigurationReference?.uuid, debugRef.uuid);
+      }
+    });
+  });
+
+  test(
       'Test DarwinAddBuildConfigurationProcessor throws when the xcconfig file reference does not exist',
       () async {
     await TestUtils.withTempDir((dir) async {

--- a/test/processors/darwin/darwin_add_build_configuration_processor_test.dart
+++ b/test/processors/darwin/darwin_add_build_configuration_processor_test.dart
@@ -109,6 +109,12 @@ void main() {
               .firstWhere((c) => c.name == '$mode-orange')
               .uuid,
       };
+      final originalProjectUuids = {
+        for (final mode in modes)
+          mode: afterFirst.buildConfigurations
+              .firstWhere((c) => c.name == '$mode-orange')
+              .uuid,
+      };
 
       for (final mode in modes) {
         await run(mode, 'Flutter/appleDebug.xcconfig');
@@ -126,13 +132,13 @@ void main() {
 
         expect(targetMatches.length, 1,
             reason: '$mode-orange must not be duplicated on the target');
-        expect(
-          reopened.buildConfigurations
-              .where((c) => c.name == '$mode-orange')
-              .length,
-          1,
-          reason: '$mode-orange must not be duplicated on the project',
-        );
+
+        final projectMatches = reopened.buildConfigurations
+            .where((c) => c.name == '$mode-orange')
+            .toList();
+        expect(projectMatches.length, 1,
+            reason: '$mode-orange must not be duplicated on the project');
+        expect(projectMatches.single.uuid, originalProjectUuids[mode]);
 
         final config = targetMatches.single;
         expect(config.uuid, originalUuids[mode]);


### PR DESCRIPTION
DarwinAddBuildConfigurationProcessor unconditionally created and appended a new XCBuildConfiguration to the native target on every run, duplicating each flavor/mode configuration when flavorizr is re-run on an already-configured project. 

Look up the configuration by name first and only create it when absent, restoring the idempotent behaviour the Ruby xcodeproj gem provided before the 2.5.0 dart_xcodeproj migration (and matching the existing project-level addBuildConfiguration guard).

Fixes #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Darwin build configurations from being created on native targets.
  * Existing configurations are now reused and updated when already present, ensuring repeated runs remain idempotent.
* **Tests**
  * Added coverage to verify idempotency across Debug, Profile, and Release builds, including stable configuration UUIDs and correct build settings references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->