### PR TITLE
fix: update dart_xcodeproj to v0.3.0 and add macro expansion for profile action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 * Added support for Linux platform (`linux:cmake`, `linux:runnerCmake`, `linux:myApplication` processors)
 * Added support for Windows platform (`windows:cmake`, `windows:mainCppTemplate`, `windows:runnerRcTemplate`, `windows:dummyAssets`, `windows:icons` processors) — sets the per-flavor window title and app icon
 * Generated flavor schemes now include testable references for unit-test and UI-testing targets
-* Fixed missing macro expansion for profile action in generated Xcode schemes
+* Fixed generated Xcode schemes: added `BuildableProductRunnable` to `ProfileAction` and `MacroExpansion` to `TestAction`
+* Fixed duplicate build configurations being created on native targets when re-running flavorizr on an already-configured project
 
 ## 2.5.0
 * Replaced Ruby xcodeproj gem with dart_xcodeproj — no Ruby/gem installation required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 * Added support for Linux platform (`linux:cmake`, `linux:runnerCmake`, `linux:myApplication` processors)
 * Added support for Windows platform (`windows:cmake`, `windows:mainCppTemplate`, `windows:runnerRcTemplate`, `windows:dummyAssets`, `windows:icons` processors) — sets the per-flavor window title and app icon
+* Generated flavor schemes now include testable references for unit-test and UI-testing targets
+* Fixed missing macro expansion for profile action in generated Xcode schemes
 
 ## 2.5.0
 * Replaced Ruby xcodeproj gem with dart_xcodeproj — no Ruby/gem installation required

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: dart_xcodeproj
-      sha256: ba9f4772cb78d9a2b8e37dccda198cdba335994624a624ec30df5cfb396dd68a
+      sha256: bf7c7f4830adef81367222bbb299c1856c50a8487ff72a74635f37af255188bb
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   fake_async:
     dependency: transitive
     description:

--- a/lib/src/processors/darwin/darwin_create_scheme_processor.dart
+++ b/lib/src/processors/darwin/darwin_create_scheme_processor.dart
@@ -28,6 +28,11 @@ import 'package:flutter_flavorizr/src/parser/models/flavorizr.dart';
 import 'package:flutter_flavorizr/src/processors/commons/abstract_processor.dart';
 import 'package:mason_logger/mason_logger.dart';
 
+const _testProductTypes = {
+  'com.apple.product-type.bundle.unit-test',
+  'com.apple.product-type.bundle.ui-testing',
+};
+
 class DarwinCreateSchemeProcessor extends AbstractProcessor<void> {
   final String projectPath;
   final String schemeName;
@@ -67,6 +72,25 @@ class DarwinCreateSchemeProcessor extends AbstractProcessor<void> {
     final macroExpansion = MacroExpansion();
     macroExpansion.setBuildableReference(ref);
     scheme.testAction.addMacroExpansion(macroExpansion);
+
+    final testTargets = project.targets
+        .whereType<PBXNativeTarget>()
+        .where((target) => _testProductTypes.contains(target.productType));
+
+    for (final testTarget in testTargets) {
+      final testRef = BuildableReference()
+        ..setReferenceTarget(
+          testTarget.uuid,
+          '${testTarget.productName ?? testTarget.name}.xctest',
+          testTarget.name!,
+          'container:${project.name}.xcodeproj',
+        );
+      final testable = TestableReference()
+        ..skipped = false
+        ..parallelizable = false
+        ..addBuildableReference(testRef);
+      scheme.testAction.addTestable(testable);
+    }
 
     await scheme.saveAs(
         '$projectPath/xcshareddata/xcschemes/$schemeName.xcscheme');

--- a/lib/src/processors/darwin/darwin_create_scheme_processor.dart
+++ b/lib/src/processors/darwin/darwin_create_scheme_processor.dart
@@ -62,6 +62,11 @@ class DarwinCreateSchemeProcessor extends AbstractProcessor<void> {
     runnable.runnableDebuggingMode = '0';
     runnable.buildableReference = ref;
     scheme.launchAction.buildableProductRunnable = runnable;
+    scheme.profileAction.buildableProductRunnable = runnable;
+
+    final macroExpansion = MacroExpansion();
+    macroExpansion.setBuildableReference(ref);
+    scheme.testAction.addMacroExpansion(macroExpansion);
 
     await scheme.saveAs(
         '$projectPath/xcshareddata/xcschemes/$schemeName.xcscheme');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_xcodeproj
-      sha256: ba9f4772cb78d9a2b8e37dccda198cdba335994624a624ec30df5cfb396dd68a
+      sha256: bf7c7f4830adef81367222bbb299c1856c50a8487ff72a74635f37af255188bb
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   args: ^2.4.2
   checked_yaml: ^2.0.3
   collection: ^1.18.0
-  dart_xcodeproj: ^0.2.0
+  dart_xcodeproj: ^0.3.0
   image: ^4.9.1
   io: ^1.0.4
   json_annotation: ^4.8.1

--- a/test/processors/darwin/darwin_create_scheme_processor_test.dart
+++ b/test/processors/darwin/darwin_create_scheme_processor_test.dart
@@ -25,6 +25,7 @@
 
 import 'dart:io';
 
+import 'package:dart_xcodeproj/dart_xcodeproj.dart';
 import 'package:flutter_flavorizr/src/parser/models/flavorizr.dart';
 import 'package:flutter_flavorizr/src/processors/darwin/darwin_create_scheme_processor.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -45,65 +46,138 @@ void main() {
   });
 
   test(
-      'Test DarwinCreateSchemeProcessor writes an xcscheme file with the flavor build configurations',
-      () async {
-    await TestUtils.withTempDir((dir) async {
-      final projectPath = '${dir.path}/Runner.xcodeproj';
-      copyPathSync(exampleProjectPath, projectPath);
+    'Test DarwinCreateSchemeProcessor writes an xcscheme file with the flavor build configurations',
+    () async {
+      await TestUtils.withTempDir((dir) async {
+        final projectPath = '${dir.path}/Runner.xcodeproj';
+        copyPathSync(exampleProjectPath, projectPath);
 
-      final processor = DarwinCreateSchemeProcessor(
-        projectPath,
-        'orange',
-        config: flavorizr,
-        logger: logger,
-      );
+        final processor = DarwinCreateSchemeProcessor(
+          projectPath,
+          'orange',
+          config: flavorizr,
+          logger: logger,
+        );
 
-      await processor.execute();
+        await processor.execute();
 
-      final schemeFile =
-          File('$projectPath/xcshareddata/xcschemes/orange.xcscheme');
-      expect(schemeFile.existsSync(), isTrue);
+        final schemeFile = File(
+          '$projectPath/xcshareddata/xcschemes/orange.xcscheme',
+        );
+        expect(schemeFile.existsSync(), isTrue);
 
-      final content = schemeFile.readAsStringSync();
-      expect(content, contains('Debug-orange'));
-      expect(content, contains('Release-orange'));
-      expect(content, contains('Profile-orange'));
+        final content = schemeFile.readAsStringSync();
+        expect(content, contains('Debug-orange'));
+        expect(content, contains('Release-orange'));
+        expect(content, contains('Profile-orange'));
 
-      final launchActionMatch = RegExp(
-        r'<LaunchAction[\s\S]*?</LaunchAction>',
-      ).firstMatch(content);
-      expect(launchActionMatch, isNotNull);
-      expect(
-        launchActionMatch!.group(0),
-        contains('BuildableProductRunnable'),
-      );
+        final launchActionMatch = RegExp(
+          r'<LaunchAction[\s\S]*?</LaunchAction>',
+        ).firstMatch(content);
+        expect(launchActionMatch, isNotNull);
+        expect(
+          launchActionMatch!.group(0),
+          contains('BuildableProductRunnable'),
+        );
 
-      final profileActionMatch = RegExp(
-        r'<ProfileAction[\s\S]*?</ProfileAction>',
-      ).firstMatch(content);
-      expect(profileActionMatch, isNotNull);
-      final profileActionContent = profileActionMatch!.group(0)!;
-      expect(profileActionContent, contains('BuildableProductRunnable'));
-      expect(profileActionContent, contains('BuildableName = "Runner.app"'));
-      expect(profileActionContent, contains('BlueprintName = "Runner"'));
-      expect(
-        profileActionContent,
-        contains('ReferencedContainer = "container:Runner.xcodeproj"'),
-      );
+        final profileActionMatch = RegExp(
+          r'<ProfileAction[\s\S]*?</ProfileAction>',
+        ).firstMatch(content);
+        expect(profileActionMatch, isNotNull);
+        final profileActionContent = profileActionMatch!.group(0)!;
+        expect(profileActionContent, contains('BuildableProductRunnable'));
+        expect(profileActionContent, contains('BuildableName = "Runner.app"'));
+        expect(profileActionContent, contains('BlueprintName = "Runner"'));
+        expect(
+          profileActionContent,
+          contains('ReferencedContainer = "container:Runner.xcodeproj"'),
+        );
 
-      final testActionMatch = RegExp(
-        r'<TestAction[\s\S]*?</TestAction>',
-      ).firstMatch(content);
-      expect(testActionMatch, isNotNull);
-      final testActionContent = testActionMatch!.group(0)!;
-      expect(testActionContent, contains('MacroExpansion'));
-      expect(testActionContent, contains('BuildableName = "Runner.app"'));
-      expect(testActionContent, contains('BlueprintName = "Runner"'));
-      expect(
-        testActionContent,
-        contains('ReferencedContainer = "container:Runner.xcodeproj"'),
-      );
-    });
-  });
+        final testActionMatch = RegExp(
+          r'<TestAction[\s\S]*?</TestAction>',
+        ).firstMatch(content);
+        expect(testActionMatch, isNotNull);
+        final testActionContent = testActionMatch!.group(0)!;
+        expect(testActionContent, contains('MacroExpansion'));
+        expect(testActionContent, contains('BuildableName = "Runner.app"'));
+        expect(testActionContent, contains('BlueprintName = "Runner"'));
+        expect(
+          testActionContent,
+          contains('ReferencedContainer = "container:Runner.xcodeproj"'),
+        );
+        expect(testActionContent, contains('<Testables>'));
+        expect(
+          testActionContent,
+          contains('BuildableName = "RunnerTests.xctest"'),
+        );
+        expect(testActionContent, contains('BlueprintName = "RunnerTests"'));
+      });
+    },
+  );
 
+  test(
+    'Test DarwinCreateSchemeProcessor does not duplicate testables when run twice',
+    () async {
+      await TestUtils.withTempDir((dir) async {
+        final projectPath = '${dir.path}/Runner.xcodeproj';
+        copyPathSync(exampleProjectPath, projectPath);
+
+        final processor = DarwinCreateSchemeProcessor(
+          projectPath,
+          'orange',
+          config: flavorizr,
+          logger: logger,
+        );
+
+        await processor.execute();
+        await processor.execute();
+
+        final content = File(
+          '$projectPath/xcshareddata/xcschemes/orange.xcscheme',
+        ).readAsStringSync();
+
+        expect(
+          'BuildableName = "RunnerTests.xctest"'.allMatches(content).length,
+          1,
+        );
+      });
+    },
+  );
+
+  test(
+    'Test DarwinCreateSchemeProcessor generates testables for unit-test and ui-testing targets',
+    () async {
+      await TestUtils.withTempDir((dir) async {
+        final projectPath = '${dir.path}/Runner.xcodeproj';
+        copyPathSync(exampleProjectPath, projectPath);
+
+        // The example project ships a unit-test target (RunnerTests); add a
+        // ui-testing target so both product types are exercised.
+        final project = await XcodeProject.open(projectPath);
+        final uiTestTarget =
+            project.newObject<PBXNativeTarget>((g, u) => PBXNativeTarget(g, u))
+              ..name = 'RunnerUITests'
+              ..productName = 'RunnerUITests'
+              ..productType = 'com.apple.product-type.bundle.ui-testing';
+        project.targets.add(uiTestTarget);
+        await project.save();
+
+        final processor = DarwinCreateSchemeProcessor(
+          projectPath,
+          'orange',
+          config: flavorizr,
+          logger: logger,
+        );
+
+        await processor.execute();
+
+        final content = File(
+          '$projectPath/xcshareddata/xcschemes/orange.xcscheme',
+        ).readAsStringSync();
+
+        expect(content, contains('BuildableName = "RunnerTests.xctest"'));
+        expect(content, contains('BuildableName = "RunnerUITests.xctest"'));
+      });
+    },
+  );
 }

--- a/test/processors/darwin/darwin_create_scheme_processor_test.dart
+++ b/test/processors/darwin/darwin_create_scheme_processor_test.dart
@@ -68,6 +68,21 @@ void main() {
       expect(content, contains('Debug-orange'));
       expect(content, contains('Release-orange'));
       expect(content, contains('Profile-orange'));
+
+      final profileActionMatch = RegExp(
+        r'<ProfileAction[\s\S]*?</ProfileAction>',
+      ).firstMatch(content);
+      expect(profileActionMatch, isNotNull);
+      expect(
+        profileActionMatch!.group(0),
+        contains('BuildableProductRunnable'),
+      );
+
+      final testActionMatch = RegExp(
+        r'<TestAction[\s\S]*?</TestAction>',
+      ).firstMatch(content);
+      expect(testActionMatch, isNotNull);
+      expect(testActionMatch!.group(0), contains('MacroExpansion'));
     });
   });
 

--- a/test/processors/darwin/darwin_create_scheme_processor_test.dart
+++ b/test/processors/darwin/darwin_create_scheme_processor_test.dart
@@ -69,20 +69,40 @@ void main() {
       expect(content, contains('Release-orange'));
       expect(content, contains('Profile-orange'));
 
+      final launchActionMatch = RegExp(
+        r'<LaunchAction[\s\S]*?</LaunchAction>',
+      ).firstMatch(content);
+      expect(launchActionMatch, isNotNull);
+      expect(
+        launchActionMatch!.group(0),
+        contains('BuildableProductRunnable'),
+      );
+
       final profileActionMatch = RegExp(
         r'<ProfileAction[\s\S]*?</ProfileAction>',
       ).firstMatch(content);
       expect(profileActionMatch, isNotNull);
+      final profileActionContent = profileActionMatch!.group(0)!;
+      expect(profileActionContent, contains('BuildableProductRunnable'));
+      expect(profileActionContent, contains('BuildableName = "Runner.app"'));
+      expect(profileActionContent, contains('BlueprintName = "Runner"'));
       expect(
-        profileActionMatch!.group(0),
-        contains('BuildableProductRunnable'),
+        profileActionContent,
+        contains('ReferencedContainer = "container:Runner.xcodeproj"'),
       );
 
       final testActionMatch = RegExp(
         r'<TestAction[\s\S]*?</TestAction>',
       ).firstMatch(content);
       expect(testActionMatch, isNotNull);
-      expect(testActionMatch!.group(0), contains('MacroExpansion'));
+      final testActionContent = testActionMatch!.group(0)!;
+      expect(testActionContent, contains('MacroExpansion'));
+      expect(testActionContent, contains('BuildableName = "Runner.app"'));
+      expect(testActionContent, contains('BlueprintName = "Runner"'));
+      expect(
+        testActionContent,
+        contains('ReferencedContainer = "container:Runner.xcodeproj"'),
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated Xcode flavor schemes so the Profile action references the correct built product.
  * Improved Test action generation to include unit and UI testables correctly, filtering targets appropriately and preventing duplicate testables on re-runs.
* **Tests**
  * Expanded validation of generated scheme XML for launch, profile, and test actions, including runnable/macro and reference details.
  * Added coverage for generating both unit-test and UI-testables and verifying repeated execution doesn’t duplicate entries.
* **Chores**
  * Updated the Dart Xcode project dependency version used by the Flutter project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->