### PR TITLE
feat: generate testable references for test targets in schemes

### DIFF
--- a/lib/src/processors/darwin/darwin_create_scheme_processor.dart
+++ b/lib/src/processors/darwin/darwin_create_scheme_processor.dart
@@ -28,6 +28,11 @@ import 'package:flutter_flavorizr/src/parser/models/flavorizr.dart';
 import 'package:flutter_flavorizr/src/processors/commons/abstract_processor.dart';
 import 'package:mason_logger/mason_logger.dart';
 
+const _testProductTypes = {
+  'com.apple.product-type.bundle.unit-test',
+  'com.apple.product-type.bundle.ui-testing',
+};
+
 class DarwinCreateSchemeProcessor extends AbstractProcessor<void> {
   final String projectPath;
   final String schemeName;
@@ -68,14 +73,11 @@ class DarwinCreateSchemeProcessor extends AbstractProcessor<void> {
     macroExpansion.setBuildableReference(ref);
     scheme.testAction.addMacroExpansion(macroExpansion);
 
-    const testProductTypes = {
-      'com.apple.product-type.bundle.unit-test',
-      'com.apple.product-type.bundle.ui-testing',
-    };
-    for (final testTarget in project.targets.whereType<PBXNativeTarget>()) {
-      if (!testProductTypes.contains(testTarget.productType)) {
-        continue;
-      }
+    final testTargets = project.targets
+        .whereType<PBXNativeTarget>()
+        .where((target) => _testProductTypes.contains(target.productType));
+
+    for (final testTarget in testTargets) {
       final testRef = BuildableReference()
         ..setReferenceTarget(
           testTarget.uuid,

--- a/lib/src/processors/darwin/darwin_create_scheme_processor.dart
+++ b/lib/src/processors/darwin/darwin_create_scheme_processor.dart
@@ -79,7 +79,7 @@ class DarwinCreateSchemeProcessor extends AbstractProcessor<void> {
       final testRef = BuildableReference()
         ..setReferenceTarget(
           testTarget.uuid,
-          '${testTarget.name}.xctest',
+          '${testTarget.productName ?? testTarget.name}.xctest',
           testTarget.name!,
           'container:${project.name}.xcodeproj',
         );

--- a/lib/src/processors/darwin/darwin_create_scheme_processor.dart
+++ b/lib/src/processors/darwin/darwin_create_scheme_processor.dart
@@ -68,6 +68,28 @@ class DarwinCreateSchemeProcessor extends AbstractProcessor<void> {
     macroExpansion.setBuildableReference(ref);
     scheme.testAction.addMacroExpansion(macroExpansion);
 
+    const testProductTypes = {
+      'com.apple.product-type.bundle.unit-test',
+      'com.apple.product-type.bundle.ui-testing',
+    };
+    for (final testTarget in project.targets.whereType<PBXNativeTarget>()) {
+      if (!testProductTypes.contains(testTarget.productType)) {
+        continue;
+      }
+      final testRef = BuildableReference()
+        ..setReferenceTarget(
+          testTarget.uuid,
+          '${testTarget.name}.xctest',
+          testTarget.name!,
+          'container:${project.name}.xcodeproj',
+        );
+      final testable = TestableReference()
+        ..skipped = false
+        ..parallelizable = false
+        ..addBuildableReference(testRef);
+      scheme.testAction.addTestable(testable);
+    }
+
     await scheme.saveAs(
         '$projectPath/xcshareddata/xcschemes/$schemeName.xcscheme');
   }

--- a/test/processors/darwin/darwin_create_scheme_processor_test.dart
+++ b/test/processors/darwin/darwin_create_scheme_processor_test.dart
@@ -25,6 +25,7 @@
 
 import 'dart:io';
 
+import 'package:dart_xcodeproj/dart_xcodeproj.dart';
 import 'package:flutter_flavorizr/src/parser/models/flavorizr.dart';
 import 'package:flutter_flavorizr/src/processors/darwin/darwin_create_scheme_processor.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -45,98 +46,138 @@ void main() {
   });
 
   test(
-      'Test DarwinCreateSchemeProcessor writes an xcscheme file with the flavor build configurations',
-      () async {
-    await TestUtils.withTempDir((dir) async {
-      final projectPath = '${dir.path}/Runner.xcodeproj';
-      copyPathSync(exampleProjectPath, projectPath);
+    'Test DarwinCreateSchemeProcessor writes an xcscheme file with the flavor build configurations',
+    () async {
+      await TestUtils.withTempDir((dir) async {
+        final projectPath = '${dir.path}/Runner.xcodeproj';
+        copyPathSync(exampleProjectPath, projectPath);
 
-      final processor = DarwinCreateSchemeProcessor(
-        projectPath,
-        'orange',
-        config: flavorizr,
-        logger: logger,
-      );
+        final processor = DarwinCreateSchemeProcessor(
+          projectPath,
+          'orange',
+          config: flavorizr,
+          logger: logger,
+        );
 
-      await processor.execute();
+        await processor.execute();
 
-      final schemeFile =
-          File('$projectPath/xcshareddata/xcschemes/orange.xcscheme');
-      expect(schemeFile.existsSync(), isTrue);
+        final schemeFile = File(
+          '$projectPath/xcshareddata/xcschemes/orange.xcscheme',
+        );
+        expect(schemeFile.existsSync(), isTrue);
 
-      final content = schemeFile.readAsStringSync();
-      expect(content, contains('Debug-orange'));
-      expect(content, contains('Release-orange'));
-      expect(content, contains('Profile-orange'));
+        final content = schemeFile.readAsStringSync();
+        expect(content, contains('Debug-orange'));
+        expect(content, contains('Release-orange'));
+        expect(content, contains('Profile-orange'));
 
-      final launchActionMatch = RegExp(
-        r'<LaunchAction[\s\S]*?</LaunchAction>',
-      ).firstMatch(content);
-      expect(launchActionMatch, isNotNull);
-      expect(
-        launchActionMatch!.group(0),
-        contains('BuildableProductRunnable'),
-      );
+        final launchActionMatch = RegExp(
+          r'<LaunchAction[\s\S]*?</LaunchAction>',
+        ).firstMatch(content);
+        expect(launchActionMatch, isNotNull);
+        expect(
+          launchActionMatch!.group(0),
+          contains('BuildableProductRunnable'),
+        );
 
-      final profileActionMatch = RegExp(
-        r'<ProfileAction[\s\S]*?</ProfileAction>',
-      ).firstMatch(content);
-      expect(profileActionMatch, isNotNull);
-      final profileActionContent = profileActionMatch!.group(0)!;
-      expect(profileActionContent, contains('BuildableProductRunnable'));
-      expect(profileActionContent, contains('BuildableName = "Runner.app"'));
-      expect(profileActionContent, contains('BlueprintName = "Runner"'));
-      expect(
-        profileActionContent,
-        contains('ReferencedContainer = "container:Runner.xcodeproj"'),
-      );
+        final profileActionMatch = RegExp(
+          r'<ProfileAction[\s\S]*?</ProfileAction>',
+        ).firstMatch(content);
+        expect(profileActionMatch, isNotNull);
+        final profileActionContent = profileActionMatch!.group(0)!;
+        expect(profileActionContent, contains('BuildableProductRunnable'));
+        expect(profileActionContent, contains('BuildableName = "Runner.app"'));
+        expect(profileActionContent, contains('BlueprintName = "Runner"'));
+        expect(
+          profileActionContent,
+          contains('ReferencedContainer = "container:Runner.xcodeproj"'),
+        );
 
-      final testActionMatch = RegExp(
-        r'<TestAction[\s\S]*?</TestAction>',
-      ).firstMatch(content);
-      expect(testActionMatch, isNotNull);
-      final testActionContent = testActionMatch!.group(0)!;
-      expect(testActionContent, contains('MacroExpansion'));
-      expect(testActionContent, contains('BuildableName = "Runner.app"'));
-      expect(testActionContent, contains('BlueprintName = "Runner"'));
-      expect(
-        testActionContent,
-        contains('ReferencedContainer = "container:Runner.xcodeproj"'),
-      );
-      expect(testActionContent, contains('<Testables>'));
-      expect(
-        testActionContent,
-        contains('BuildableName = "RunnerTests.xctest"'),
-      );
-      expect(testActionContent, contains('BlueprintName = "RunnerTests"'));
-    });
-  });
+        final testActionMatch = RegExp(
+          r'<TestAction[\s\S]*?</TestAction>',
+        ).firstMatch(content);
+        expect(testActionMatch, isNotNull);
+        final testActionContent = testActionMatch!.group(0)!;
+        expect(testActionContent, contains('MacroExpansion'));
+        expect(testActionContent, contains('BuildableName = "Runner.app"'));
+        expect(testActionContent, contains('BlueprintName = "Runner"'));
+        expect(
+          testActionContent,
+          contains('ReferencedContainer = "container:Runner.xcodeproj"'),
+        );
+        expect(testActionContent, contains('<Testables>'));
+        expect(
+          testActionContent,
+          contains('BuildableName = "RunnerTests.xctest"'),
+        );
+        expect(testActionContent, contains('BlueprintName = "RunnerTests"'));
+      });
+    },
+  );
 
   test(
-      'Test DarwinCreateSchemeProcessor does not duplicate testables when run twice',
-      () async {
-    await TestUtils.withTempDir((dir) async {
-      final projectPath = '${dir.path}/Runner.xcodeproj';
-      copyPathSync(exampleProjectPath, projectPath);
+    'Test DarwinCreateSchemeProcessor does not duplicate testables when run twice',
+    () async {
+      await TestUtils.withTempDir((dir) async {
+        final projectPath = '${dir.path}/Runner.xcodeproj';
+        copyPathSync(exampleProjectPath, projectPath);
 
-      final processor = DarwinCreateSchemeProcessor(
-        projectPath,
-        'orange',
-        config: flavorizr,
-        logger: logger,
-      );
+        final processor = DarwinCreateSchemeProcessor(
+          projectPath,
+          'orange',
+          config: flavorizr,
+          logger: logger,
+        );
 
-      await processor.execute();
-      await processor.execute();
+        await processor.execute();
+        await processor.execute();
 
-      final content =
-          File('$projectPath/xcshareddata/xcschemes/orange.xcscheme')
-              .readAsStringSync();
+        final content = File(
+          '$projectPath/xcshareddata/xcschemes/orange.xcscheme',
+        ).readAsStringSync();
 
-      expect(
-        'BuildableName = "RunnerTests.xctest"'.allMatches(content).length,
-        1,
-      );
-    });
-  });
+        expect(
+          'BuildableName = "RunnerTests.xctest"'.allMatches(content).length,
+          1,
+        );
+      });
+    },
+  );
+
+  test(
+    'Test DarwinCreateSchemeProcessor generates testables for unit-test and ui-testing targets',
+    () async {
+      await TestUtils.withTempDir((dir) async {
+        final projectPath = '${dir.path}/Runner.xcodeproj';
+        copyPathSync(exampleProjectPath, projectPath);
+
+        // The example project ships a unit-test target (RunnerTests); add a
+        // ui-testing target so both product types are exercised.
+        final project = await XcodeProject.open(projectPath);
+        final uiTestTarget =
+            project.newObject<PBXNativeTarget>((g, u) => PBXNativeTarget(g, u))
+              ..name = 'RunnerUITests'
+              ..productName = 'RunnerUITests'
+              ..productType = 'com.apple.product-type.bundle.ui-testing';
+        project.targets.add(uiTestTarget);
+        await project.save();
+
+        final processor = DarwinCreateSchemeProcessor(
+          projectPath,
+          'orange',
+          config: flavorizr,
+          logger: logger,
+        );
+
+        await processor.execute();
+
+        final content = File(
+          '$projectPath/xcshareddata/xcschemes/orange.xcscheme',
+        ).readAsStringSync();
+
+        expect(content, contains('BuildableName = "RunnerTests.xctest"'));
+        expect(content, contains('BuildableName = "RunnerUITests.xctest"'));
+      });
+    },
+  );
 }

--- a/test/processors/darwin/darwin_create_scheme_processor_test.dart
+++ b/test/processors/darwin/darwin_create_scheme_processor_test.dart
@@ -103,7 +103,40 @@ void main() {
         testActionContent,
         contains('ReferencedContainer = "container:Runner.xcodeproj"'),
       );
+      expect(testActionContent, contains('<Testables>'));
+      expect(
+        testActionContent,
+        contains('BuildableName = "RunnerTests.xctest"'),
+      );
+      expect(testActionContent, contains('BlueprintName = "RunnerTests"'));
     });
   });
 
+  test(
+      'Test DarwinCreateSchemeProcessor does not duplicate testables when run twice',
+      () async {
+    await TestUtils.withTempDir((dir) async {
+      final projectPath = '${dir.path}/Runner.xcodeproj';
+      copyPathSync(exampleProjectPath, projectPath);
+
+      final processor = DarwinCreateSchemeProcessor(
+        projectPath,
+        'orange',
+        config: flavorizr,
+        logger: logger,
+      );
+
+      await processor.execute();
+      await processor.execute();
+
+      final content =
+          File('$projectPath/xcshareddata/xcschemes/orange.xcscheme')
+              .readAsStringSync();
+
+      expect(
+        'BuildableName = "RunnerTests.xctest"'.allMatches(content).length,
+        1,
+      );
+    });
+  });
 }


### PR DESCRIPTION
Closes #449

`DarwinCreateSchemeProcessor` now emits a `<TestableReference>` for every native
target whose `productType` is a test bundle (`unit-test` / `ui-testing`), so
generated flavor schemes are runnable for testing without a post-processing
script. Detection is by `productType`, so it works for any project's test
targets with no configuration.

Uses only existing `dart_xcodeproj 0.3.0` APIs. Schemes are regenerated and
overwritten each run, so exactly one testable per test target is produced (no
duplication on rerun).

**Testing:** extends `darwin_create_scheme_processor_test.dart` to assert a
testable is generated for the example project's unit-test target, plus a rerun
test asserting it is not duplicated.

**Note:** builds on #447 — best rebased onto `master` once that merges so the
diff shows only this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated macOS/iOS schemes now automatically include the appropriate unit-test and UI-test targets in the scheme’s test action.
  * Added consistent test execution settings (non-parallel) for included test targets.
* **Bug Fixes**
  * Prevented duplicate test-target entries when regenerating an existing scheme.
* **Tests**
  * Expanded validation of the generated `orange.xcscheme` test action XML, including stable (non-duplicative) output across repeated runs and coverage for both unit-test and UI-test targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->